### PR TITLE
Add macOS and C++ 11 backward compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,32 +2,50 @@ cmake_minimum_required(VERSION 3.10)
 project(shadesmar)
 SET(CMAKE_VERBOSE_MAKEFILE 1)
 
-find_package(Boost)
+find_package(Boost REQUIRED)
+find_package(msgpack REQUIRED)
+
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "-pthread -lstdc++fs")
+set(libs ${Boost_LIBRARIES})
+
+if (APPLE)
+  if(${CMAKE_OSX_DEPLOYMENT_TARGET} EQUAL "10.15")
+    set(CMAKE_CXX_STANDARD 17)
+  else()
+    set(CMAKE_CXX_STANDARD 11)
+  endif()
+endif()
+
+if(UNIX AND NOT APPLE)
+    list(APPEND libs rt pthread stdc++fs)
+endif()
 
 add_compile_options(-O2)
 add_compile_options(-DDEBUG_BUILD)
 
-include_directories(include)
+
+include_directories(include ${Boost_INCLUDE_DIRS})
 
 add_executable(publish src/publisher.cpp)
-target_link_libraries(publish ${Boost_LIBRARIES} rt stdc++fs)
+target_link_libraries(publish ${libs})
 
 add_executable(subscribe src/subscriber.cpp)
-target_link_libraries(subscribe ${Boost_LIBRARIES} rt stdc++fs)
+target_link_libraries(subscribe ${libs})
 
 add_executable(flush_topic src/flush_topic.cpp)
-target_link_libraries(flush_topic ${Boost_LIBRARIES} rt stdc++fs)
+target_link_libraries(flush_topic ${libs})
 
 add_executable(serialize_msg src/serialize_msg.cpp)
-target_link_libraries(serialize_msg ${Boost_LIBRARIES} rt stdc++fs)
+target_link_libraries(serialize_msg ${libs})
 
 add_executable(benchmark src/benchmark.cpp)
-target_link_libraries(benchmark ${Boost_LIBRARIES} rt stdc++fs)
+target_link_libraries(benchmark ${libs})
 
 add_executable(micro_bench src/micro_bench.cpp)
-target_link_libraries(micro_bench ${Boost_LIBRARIES} rt stdc++fs)
+target_link_libraries(micro_bench ${libs})
 
 add_executable(raw_benchmark src/raw_benchmark.cpp)
-target_link_libraries(raw_benchmark ${Boost_LIBRARIES} rt stdc++fs)
+target_link_libraries(raw_benchmark ${libs})
+
+add_executable(tmp_test src/tmp_test.cpp)
+target_link_libraries(tmp_test ${libs})

--- a/include/shadesmar/ipc_lock.h
+++ b/include/shadesmar/ipc_lock.h
@@ -5,6 +5,10 @@
 #ifndef shadesmar_IPC_LOCK_H
 #define shadesmar_IPC_LOCK_H
 
+#ifdef __APPLE__
+  #define __pid_t __darwin_pid_t
+#endif
+
 #include <sys/stat.h>
 
 #include <cstdint>

--- a/include/shadesmar/subscriber.h
+++ b/include/shadesmar/subscriber.h
@@ -71,7 +71,13 @@ template <uint32_t queue_size>
 SubscriberBase<queue_size>::SubscriberBase(std::string topic_name)
     : topic_name_(topic_name) {
   std::this_thread::sleep_for(std::chrono::microseconds(2000));
-  topic = std::make_unique<Memory<queue_size>>(topic_name_);
+
+  #if __cplusplus >= 201703L
+    topic = std::make_unique<Memory<queue_size>>(topic_name_);
+  #else
+    topic = std::unique_ptr<Memory<queue_size>>(new Memory<queue_size>(std::forward<std::string>(topic_name_)));
+  #endif
+
   counter = topic->counter();
 }
 


### PR DESCRIPTION
Complete C++ 17 support comes only with macOS 10.14, so previous versions have to fallback to C++ 11.

Added alternate C methods for filesystem manipulation since std::filesystem is available only on C++ 17 onwards.

Tested on macOS 10.14, Ubuntu 18.04.
Compiled for macOS 10.15 but haven't executed.