### PR TITLE
Remove multi-threaded copiers

### DIFF
--- a/benchmark/dragons.cpp
+++ b/benchmark/dragons.cpp
@@ -51,9 +51,10 @@ SHM_COPY_BENCHMARK(shm::memory::DefaultCopier);
 #ifndef __APPLE__  // no MaxOS support
 
 SHM_COPY_BENCHMARK(shm::memory::dragons::RepMovsbCopier);
+SHM_COPY_BENCHMARK(shm::memory::dragons::AvxCopier);
 SHM_COPY_BENCHMARK(shm::memory::dragons::AvxAsyncCopier);
-SHM_COPY_BENCHMARK(shm::memory::dragons::MTCopier);
-SHM_COPY_BENCHMARK(shm::memory::dragons::MTAvxAsyncCopier);
+SHM_COPY_BENCHMARK(shm::memory::dragons::AvxAsyncPFCopier);
+SHM_COPY_BENCHMARK(shm::memory::dragons::AvxUnrollCopier);
 
 #endif
 BENCHMARK_MAIN();

--- a/test/dragons_test.cpp
+++ b/test/dragons_test.cpp
@@ -63,10 +63,11 @@ int main() {
     std::cout << "Memory size: 2 ^ " << i << std::endl;
     test<shm::memory::DefaultCopier>(mem_size, i);
 #ifndef __APPLE__  // no MaxOS support
-    test<shm::memory::dragons::RepMovsbCopier>(mem_size, i + 1);
-    test<shm::memory::dragons::MTCopier>(mem_size + i, i + 2);
-    test<shm::memory::dragons::AvxAsyncCopier>(mem_size + i, i + 3);
-    test<shm::memory::dragons::MTAvxAsyncCopier>(mem_size + i, i + 4);
+    test<shm::memory::dragons::RepMovsbCopier>(mem_size, i);
+    test<shm::memory::dragons::AvxCopier>(mem_size + i, i);
+    test<shm::memory::dragons::AvxAsyncCopier>(mem_size + i, i);
+    test<shm::memory::dragons::AvxAsyncPFCopier>(mem_size + i, i);
+    test<shm::memory::dragons::AvxUnrollCopier>(mem_size + i, i);
 #endif
   }
 }


### PR DESCRIPTION
Add more AVX-based copiers.
TODO: Implement a multi-threaded adapter Copier.