### PR TITLE
Fix shm namespace issue in macOS

### DIFF
--- a/include/shadesmar/memory/copier.h
+++ b/include/shadesmar/memory/copier.h
@@ -25,6 +25,7 @@ SOFTWARE.
 #define INCLUDE_SHADESMAR_MEMORY_COPIER_H_
 
 #include <cstring>
+#include <memory>
 
 namespace shm::memory {
 class Copier {

--- a/include/shadesmar/memory/dragons.h
+++ b/include/shadesmar/memory/dragons.h
@@ -26,8 +26,6 @@ SOFTWARE.
 #ifndef INCLUDE_SHADESMAR_MEMORY_DRAGONS_H_
 #define INCLUDE_SHADESMAR_MEMORY_DRAGONS_H_
 
-#ifndef __APPLE__  // no MaxOS support
-
 #include <immintrin.h>
 
 #include <cstdlib>
@@ -37,6 +35,8 @@ SOFTWARE.
 
 #include "shadesmar/memory/copier.h"
 #include "shadesmar/memory/memory.h"
+
+#ifndef __APPLE__  // no MaxOS support
 
 namespace shm::memory::dragons {
 


### PR DESCRIPTION
Fixes the failing macOS builds

Also wondering why is `shm::memory::dragons` disable for macOS? I was able to run `dragons` benchmark without any issues after enabling it for macOS.