### PR TITLE
Remove older non-c++17 code

### DIFF
--- a/include/shadesmar/memory/tmp.h
+++ b/include/shadesmar/memory/tmp.h
@@ -33,7 +33,6 @@ SOFTWARE.
 #include <string>
 #include <vector>
 
-#if __cplusplus >= 201703L
 #ifdef __cpp_lib_filesystem
 #include <filesystem>
 #else
@@ -41,10 +40,6 @@ SOFTWARE.
 namespace std {
 namespace filesystem = experimental::filesystem;
 }
-#endif
-#else
-#include <dirent.h>
-#include <stdlib.h>
 #endif
 
 namespace shm::memory::tmp {
@@ -70,12 +65,7 @@ inline bool file_exists(const std::string &file_name) {
 
 inline void write(const std::string &name) {
   if (!file_exists(tmp_prefix)) {
-#if __cplusplus >= 201703L
     std::filesystem::create_directories(tmp_prefix);
-#else
-    auto opts = S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH;
-    mkdir(tmp_prefix.c_str(), opts);
-#endif
   }
   std::fstream file;
   std::string file_name = tmp_prefix + random_string();
@@ -91,7 +81,6 @@ inline std::vector<std::string> get_tmp_names() {
     return names;
   }
 
-#if __cplusplus >= 201703L
   for (const auto &entry : std::filesystem::directory_iterator(tmp_prefix)) {
     std::fstream file;
     file.open(entry.path().generic_string(), std::ios::in);
@@ -99,21 +88,6 @@ inline std::vector<std::string> get_tmp_names() {
     file >> name;
     names.push_back(name);
   }
-#else
-  struct dirent *entry = nullptr;
-  DIR *dp = nullptr;
-  dp = opendir(tmp_prefix.c_str());
-  if (dp != nullptr) {
-    while ((entry = readdir(dp))) {
-      std::fstream file;
-      file.open(tmp_prefix + entry->d_name, std::ios::in);
-      std::string name;
-      file >> name;
-      names.push_back(name);
-    }
-  }
-  closedir(dp);
-#endif
 
   return names;
 }
@@ -128,12 +102,6 @@ inline bool exists(const std::string &name) {
   return false;
 }
 
-inline void delete_topics() {
-#if __cplusplus >= 201703L
-  std::filesystem::remove_all(tmp_prefix);
-#else
-  system(("rm -rf " + tmp_prefix).c_str());
-#endif
-}
+inline void delete_topics() { std::filesystem::remove_all(tmp_prefix); }
 }  // namespace shm::memory::tmp
 #endif  // INCLUDE_SHADESMAR_MEMORY_TMP_H_


### PR DESCRIPTION
Since other parts of the code extensively use c++ 17, it seems pointless to have code for older versions. Going forth, shadesmar will be c++17 compat only.