### PR TITLE
Refactor pubsub into regular and serialized options

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: ./scripts/install_deps.sh
-    - name: Configure
+    - name: Configure Release
       env:
         CXX: ${{ matrix.compiler }}
       run: ./configure
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: ./scripts/install_deps.sh
     - name: Configure
-      run: ./configure
+      run: ./configure Release
     - name: Build
       run: cmake --build build
     - name: Tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.10)
 
 project(shadesmar)
 
+
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -DDEBUG_BUILD")
+
 find_package(msgpack REQUIRED)
 find_package(benchmark REQUIRED)
 
@@ -14,7 +18,6 @@ if (UNIX AND NOT APPLE)
 endif ()
 
 add_compile_options(-march=native)
-add_definitions(-DDEBUG_BUILD)
 IF(SINGLE_H)
   add_definitions(-DSINGLE_HEADER)
 ENDIF(SINGLE_H)

--- a/README.md
+++ b/README.md
@@ -30,9 +30,64 @@ pass raw bytes.
 * No need to define external IDL files for messages. Use C++ classes as
 message definition.
 
+
 ---
 
+#### Publish-Subscribe
+
+Publisher:
+```c++
+#include <shadesmar/memory/copier.h>
+#include <shadesmar/pubsub/publisher.h>
+
+int main() {
+    shm::memory::DefaultCopier cpy;
+    shm::pubsub::Publisher<16 /* buffer size */ > pub("topic_name", &cpy);
+    const uint32_t data_size = 1024;
+    void *data = malloc(data_size);
+    
+    for (int i = 0; i < 1000; ++i) {
+        p.publish(msg, data_size);
+    }
+}  
+```
+
+Subscriber:
+```c++
+#include <shadesmar/memory/copier.h>
+#include <shadesmar/pubsub/subscriber.h>
+
+void callback(shm::memory::Ptr *msg) {
+  // `msg->ptr` to access `data`
+  // `msg->size` to access `size`
+
+  // The memory will be free'd at the end of this callback.
+  // Copy to another memory location if you want to persist the data.
+  // Alternatively, if you want to avoid the copy, you can call
+  // `msg->no_delete()` which prevents the memory from being deleted
+  // at the end of the callback.
+}
+
+int main() {
+    shm::memory::DefaultCopier cpy;
+    shm::pubsub::Subscriber<16 /* buffer size */ > sub("topic_name", &cpy, callback);
+    
+    // Using `spinOnce` with a manual loop
+    while(true) {
+        sub.spin_once();
+    }
+    // OR
+    // Using `spin`
+    sub.spin();
+}
+```
+
+---
+
+
 #### Publish-Subscribe (serialized messages)
+
+For plug-and-play convenience Shadesmar supports msgpack serialization. 
 
 Message Definition (`custom_message.h`):
 ```c++
@@ -68,11 +123,11 @@ class CustomMessage : public shm::BaseMsg {
 
 Publisher:
 ```c++
-#include <shadesmar/pubsub/publisher.h>
+#include <shadesmar/pubsub/serialized_publisher.h>
 #include <custom_message.h>
 
 int main() {
-    shm::pubsub::Publisher<CustomMessage, 16 /* buffer size */ > pub("topic_name");
+    shm::pubsub::SerializedPublisher<CustomMessage, 16 /* buffer size */ > pub("topic_name");
 
     CustomMessage msg;
     msg.val = 0;
@@ -88,7 +143,7 @@ int main() {
 Subscriber:
 ```c++
 #include <iostream>
-#include <shadesmar/pubsub/subscriber.h>
+#include <shadesmar/pubsub/serialized_subscriber.h>
 #include <custom_message.h>
 
 void callback(const std::shared_ptr<CustomMessage>& msg) {
@@ -96,62 +151,11 @@ void callback(const std::shared_ptr<CustomMessage>& msg) {
 }
 
 int main() {
-    shm::pubsub::Subscriber<CustomMessage, 16 /* buffer size */ > sub("topic_name", callback);
+    shm::pubsub::SerializedSubscriber<CustomMessage, 16> sub("topic_name", callback);
     
     // Using `spinOnce` with a manual loop
     while(true) {
-        sub.spinOnce();
-    }
-    // OR
-    // Using `spin`
-    sub.spin();
-}
-```
-
----
-
-#### Publish-Subscribe (raw bytes)
-
-Publisher:
-```c++
-#include <shadesmar/memory/copier.h>
-#include <shadesmar/pubsub/publisher.h>
-
-int main() {
-    shm::memory::DefaultCopier cpy;
-    shm::pubsub::PublisherBin<16 /* buffer size */ > pub("topic_name", &cpy);
-    const uint32_t data_size = 1024;
-    void *data = malloc(data_size);
-    
-    for (int i = 0; i < 1000; ++i) {
-        p.publish(msg, data_size);
-    }
-}  
-```
-
-Subscriber:
-```c++
-#include <shadesmar/memory/copier.h>
-#include <shadesmar/pubsub/subscriber.h>
-
-void callback(shm::memory::Ptr *msg) {
-  // `msg->ptr` to access `data`
-  // `msg->size` to access `size`
-
-  // The memory will be free'd at the end of this callback.
-  // Copy to another memory location if you want to persist the data.
-  // Alternatively, if you want to avoid the copy, you can call
-  // `msg->no_delete()` which prevents the memory from being deleted
-  // at the end of the callback.
-}
-
-int main() {
-    shm::memory::DefaultCopier cpy;
-    shm::pubsub::SubscriberBin<16 /* buffer size */ > sub("topic_name", &cpy, callback);
-    
-    // Using `spinOnce` with a manual loop
-    while(true) {
-        sub.spinOnce();
+        sub.spin_once();
     }
     // OR
     // Using `spin`
@@ -198,8 +202,6 @@ int main() {
 ---
 
 **Note**: 
-
-* `shm::pubsub::Subscriber` has a boolean parameter called `extra_copy`. `extra_copy=true` is faster for smaller (<1MB) messages, and `extra_copy=false` is faster for larger (>1MB) messages. For message of 10MB, the throughput for `extra_copy=false` is nearly 50% more than `extra_copy=true`. See `_read_with_copy()` and `_read_without_copy()` in `include/shadesmar/pubsub/topic.h` for more information.
 
 * `queue_size` must be powers of 2. This is due to the underlying shared memory allocator which uses a red-black tree. See `include/shadesmar/memory/allocator.h` for more information.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Caution: Pre-alpha software.
 
 * Faster than using the network stack like in the case with ROS.
 
-* Read and write directly from GPU memory to shared memory.
-
 * Decentralized, without [resource starvation](https://squadrick.github.io/journal/ipc-locks.html).
 
 * Allows for both serialized message passing (using `msgpack`) and to 
@@ -29,7 +27,6 @@ pass raw bytes.
 
 * No need to define external IDL files for messages. Use C++ classes as
 message definition.
-
 
 ---
 
@@ -165,7 +162,7 @@ int main() {
 
 ---
 
-#### RPC
+#### RPC (Currently broken)
 
 Server:
 ```c++

--- a/configure
+++ b/configure
@@ -2,4 +2,4 @@
 
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=$1 ..

--- a/include/shadesmar/memory/memory.h
+++ b/include/shadesmar/memory/memory.h
@@ -94,6 +94,7 @@ struct Ptr {
   bool free;
 
   Ptr() : ptr(nullptr), size(0), free(false) {}
+  Ptr(void *ptr, size_t size) : ptr(ptr), size(size), free(false) {}
 
   void no_delete() { free = false; }
 };

--- a/include/shadesmar/pubsub/publisher.h
+++ b/include/shadesmar/pubsub/publisher.h
@@ -31,8 +31,6 @@ SOFTWARE.
 #include <memory>
 #include <string>
 
-#include <msgpack.hpp>
-
 #include "shadesmar/memory/copier.h"
 #include "shadesmar/message.h"
 #include "shadesmar/pubsub/topic.h"
@@ -40,65 +38,27 @@ SOFTWARE.
 namespace shm::pubsub {
 
 template <uint32_t queue_size>
-class PublisherBin {
+class Publisher {
  public:
-  explicit PublisherBin(std::string topic_name, memory::Copier *copier);
+  explicit Publisher(const std::string &topic_name, memory::Copier *copier);
   bool publish(void *data, size_t size);
 
  private:
   std::string topic_name_;
-  Topic<queue_size> topic_;
+  std::unique_ptr<Topic<queue_size>> topic_;
 };
 
 template <uint32_t queue_size>
-PublisherBin<queue_size>::PublisherBin(std::string topic_name,
-                                       memory::Copier *copier)
-    : topic_name_(topic_name), topic_(Topic<queue_size>(topic_name, copier)) {}
+Publisher<queue_size>::Publisher(const std::string &topic_name,
+                                 memory::Copier *copier)
+    : topic_name_(topic_name) {
+  topic_ = std::make_unique<Topic<queue_size>>(topic_name, copier);
+}
 
 template <uint32_t queue_size>
-bool PublisherBin<queue_size>::publish(void *data, size_t size) {
-  return topic_.write(data, size);
-}
-
-template <typename msgT, uint32_t queue_size>
-class Publisher {
- public:
-  explicit Publisher(std::string topic_name);
-  bool publish(std::shared_ptr<msgT> msg);
-  bool publish(msgT &msg);  // NOLINT
-  bool publish(msgT *msg);
-
- private:
-  std::string topic_name_;
-  Topic<queue_size> topic_;
-};
-
-template <typename msgT, uint32_t queue_size>
-Publisher<msgT, queue_size>::Publisher(std::string topic_name)
-    : topic_name_(topic_name), topic_(Topic<queue_size>(topic_name)) {
-  static_assert(std::is_base_of<BaseMsg, msgT>::value,
-                "msgT must derive from BaseMsg");
-}
-
-template <typename msgT, uint32_t queue_size>
-bool Publisher<msgT, queue_size>::publish(std::shared_ptr<msgT> msg) {
-  return publish(msg.get());
-}
-
-template <typename msgT, uint32_t queue_size>
-bool Publisher<msgT, queue_size>::publish(msgT &msg) {  // NOLINT
-  return publish(&msg);
-}
-
-template <typename msgT, uint32_t queue_size>
-bool Publisher<msgT, queue_size>::publish(msgT *msg) {
-  msgpack::sbuffer buf;
-  try {
-    msgpack::pack(buf, *msg);
-  } catch (...) {
-    return false;
-  }
-  return topic_.write(buf.data(), buf.size());
+bool Publisher<queue_size>::publish(void *data, size_t size) {
+  memory::Ptr ptr(data, size);
+  return topic_->write(ptr);
 }
 
 }  // namespace shm::pubsub

--- a/include/shadesmar/pubsub/serialized_publisher.h
+++ b/include/shadesmar/pubsub/serialized_publisher.h
@@ -1,0 +1,77 @@
+/* MIT License
+
+Copyright (c) 2020 Dheeraj R Reddy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+==============================================================================*/
+
+#ifndef INCLUDE_SHADESMAR_SERIALIZED_PUBLISHER_H_
+#define INCLUDE_SHADESMAR_SERIALIZED_PUBLISHER_H_
+
+#include <msgpack.hpp>
+
+#include "shadesmar/pubsub/publisher.h"
+
+namespace shm::pubsub {
+
+template <typename msgT, uint32_t queue_size>
+class SerializedPublisher {
+ public:
+  explicit SerializedPublisher(const std::string &topic_name,
+                               memory::Copier *copier = nullptr);
+  bool publish(std::shared_ptr<msgT> msg);
+  bool publish(msgT &msg);  // NOLINT
+  bool publish(msgT *msg);
+
+ private:
+  Publisher<queue_size> bin_pub_;
+};
+
+template <typename msgT, uint32_t queue_size>
+SerializedPublisher<msgT, queue_size>::SerializedPublisher(
+    const std::string &topic_name, memory::Copier *copier)
+    : bin_pub_(topic_name, copier) {
+  static_assert(std::is_base_of<BaseMsg, msgT>::value,
+                "msgT must derive from BaseMsg");
+}
+
+template <typename msgT, uint32_t queue_size>
+bool SerializedPublisher<msgT, queue_size>::publish(std::shared_ptr<msgT> msg) {
+  return publish(msg.get());
+}
+
+template <typename msgT, uint32_t queue_size>
+bool SerializedPublisher<msgT, queue_size>::publish(msgT &msg) {  // NOLINT
+  return publish(&msg);
+}
+
+template <typename msgT, uint32_t queue_size>
+bool SerializedPublisher<msgT, queue_size>::publish(msgT *msg) {
+  msgpack::sbuffer buf;
+  try {
+    msgpack::pack(buf, *msg);
+  } catch (...) {
+    return false;
+  }
+  return bin_pub_.publish(buf.data(), buf.size());
+}
+
+}  // namespace shm::pubsub
+
+#endif  // INCLUDE_SHADESMAR_SERIALIZED_PUBLISHER_H_

--- a/include/shadesmar/pubsub/serialized_publisher.h
+++ b/include/shadesmar/pubsub/serialized_publisher.h
@@ -21,8 +21,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ==============================================================================*/
 
-#ifndef INCLUDE_SHADESMAR_SERIALIZED_PUBLISHER_H_
-#define INCLUDE_SHADESMAR_SERIALIZED_PUBLISHER_H_
+#ifndef INCLUDE_SHADESMAR_PUBSUB_SERIALIZED_PUBLISHER_H_
+#define INCLUDE_SHADESMAR_PUBSUB_SERIALIZED_PUBLISHER_H_
+
+#include <memory>
+#include <string>
 
 #include <msgpack.hpp>
 
@@ -74,4 +77,4 @@ bool SerializedPublisher<msgT, queue_size>::publish(msgT *msg) {
 
 }  // namespace shm::pubsub
 
-#endif  // INCLUDE_SHADESMAR_SERIALIZED_PUBLISHER_H_
+#endif  // INCLUDE_SHADESMAR_PUBSUB_SERIALIZED_PUBLISHER_H_

--- a/include/shadesmar/pubsub/serialized_subscriber.h
+++ b/include/shadesmar/pubsub/serialized_subscriber.h
@@ -1,0 +1,80 @@
+/* MIT License
+
+Copyright (c) 2020 Dheeraj R Reddy
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+==============================================================================*/
+
+#ifndef INCLUDE_SHADESMAR_SERIALIZED_SUBSCRIBER_H_
+#define INCLUDE_SHADESMAR_SERIALIZED_SUBSCRIBER_H_
+
+#include <msgpack.hpp>
+
+#include "shadesmar/pubsub/subscriber.h"
+
+namespace shm::pubsub {
+
+template <typename msgT, uint32_t queue_size>
+class SerializedSubscriber {
+  static_assert(std::is_base_of<BaseMsg, msgT>::value,
+                "msgT must derive from BaseMsg");
+
+ public:
+  SerializedSubscriber(
+      const std::string &topic_name,
+      std::function<void(const std::shared_ptr<msgT> &)> callback,
+      memory::Copier *copier = nullptr);
+
+  void spin();
+  void spin_once();
+
+ private:
+  std::function<void(const std::shared_ptr<msgT> &)> callback_;
+  Subscriber<queue_size> bin_sub_;
+};
+
+template <typename msgT, uint32_t queue_size>
+SerializedSubscriber<msgT, queue_size>::SerializedSubscriber(
+    const std::string &topic_name,
+    std::function<void(const std::shared_ptr<msgT> &)> callback,
+    memory::Copier *copier)
+    : bin_sub_(topic_name, [](memory::Ptr *p) {}, copier),
+      callback_(std::move(callback)) {}
+
+template <typename msgT, uint32_t queue_size>
+void SerializedSubscriber<msgT, queue_size>::spin_once() {
+  memory::Ptr ptr = bin_sub_.get_message();
+
+  if (ptr.size == 0) {
+    return;
+  }
+  msgpack::object_handle oh =
+      msgpack::unpack(reinterpret_cast<const char *>(ptr.ptr), ptr.size);
+
+  std::shared_ptr<msgT> msg = std::make_shared<msgT>();
+  oh.get().convert(*msg);
+  msg->seq = bin_sub_.counter_;
+  callback_(msg);
+}
+
+template <typename msgT, uint32_t queue_size>
+void SerializedSubscriber<msgT, queue_size>::spin() {}
+
+}  // namespace shm::pubsub
+#endif  // INCLUDE_SHADESMAR_SERIALIZED_SUBSCRIBER_H_

--- a/include/shadesmar/pubsub/serialized_subscriber.h
+++ b/include/shadesmar/pubsub/serialized_subscriber.h
@@ -21,8 +21,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ==============================================================================*/
 
-#ifndef INCLUDE_SHADESMAR_SERIALIZED_SUBSCRIBER_H_
-#define INCLUDE_SHADESMAR_SERIALIZED_SUBSCRIBER_H_
+#ifndef INCLUDE_SHADESMAR_PUBSUB_SERIALIZED_SUBSCRIBER_H_
+#define INCLUDE_SHADESMAR_PUBSUB_SERIALIZED_SUBSCRIBER_H_
+
+#include <memory>
+#include <string>
+#include <utility>
 
 #include <msgpack.hpp>
 
@@ -77,4 +81,4 @@ template <typename msgT, uint32_t queue_size>
 void SerializedSubscriber<msgT, queue_size>::spin() {}
 
 }  // namespace shm::pubsub
-#endif  // INCLUDE_SHADESMAR_SERIALIZED_SUBSCRIBER_H_
+#endif  // INCLUDE_SHADESMAR_PUBSUB_SERIALIZED_SUBSCRIBER_H_

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# TODO: Remove this when RPC is fixed
+rm "build/rpc_test"
+
 set -e
 for f in build/*_test; do
   echo "Running test: $f"

--- a/simul/simul.py
+++ b/simul/simul.py
@@ -33,7 +33,12 @@ def fuse_lines(text_lines):
 def read_file(filename):
   text_lines = []
   with open(filename) as f:
-    return f.readlines()
+    text_lines = f.readlines()
+
+  # Add newline at end of file
+  if len(text_lines) > 0:
+    text_lines[-1] += "\n"
+  return text_lines
 
 
 def crawl_src_folder(folder):

--- a/test/pubsub_bin_test.cpp
+++ b/test/pubsub_bin_test.cpp
@@ -76,70 +76,78 @@ void callback(shm::memory::Ptr *shm_ptr) {
          msg->timestamp;
 }
 
-int main() {
-  if (fork() != 0) {
-    std::vector<int> counts;
-    std::vector<double> lags;
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-    shm::memory::DefaultCopier cpy;
-    shm::pubsub::SubscriberBin<QUEUE_SIZE> sub(topic, &cpy, callback);
-    auto start = std::chrono::system_clock::now();
-    int seconds = 0;
-    while (true) {
-      sub.spin_once();
-      auto end = std::chrono::system_clock::now();
-      auto diff = std::chrono::duration_cast<TIMESCALE>(end - start);
+void subscribe_loop() {
+  std::vector<int> counts;
+  std::vector<double> lags;
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  shm::memory::DefaultCopier cpy;
+  shm::pubsub::Subscriber<QUEUE_SIZE> sub(topic, callback, &cpy);
+  auto start = std::chrono::system_clock::now();
+  int seconds = 0;
+  while (true) {
+    sub.spin_once();
+    auto end = std::chrono::system_clock::now();
+    auto diff = std::chrono::duration_cast<TIMESCALE>(end - start);
 
-      if (diff.count() > TIMESCALE_COUNT) {
-        double lag_per_msg = static_cast<double>(lag) / count;
-        if (count != 0) {
-          std::cout << "Number of msgs sent: " << count << "/s" << std::endl;
-          std::cout << "Average Lag: " << lag_per_msg << TIMESCALE_NAME
-                    << std::endl;
+    if (diff.count() > TIMESCALE_COUNT) {
+      double lag_per_msg = static_cast<double>(lag) / count;
+      if (count != 0) {
+        std::cout << "Number of msgs sent: " << count << "/s" << std::endl;
+        std::cout << "Average Lag: " << lag_per_msg << TIMESCALE_NAME
+                  << std::endl;
 
-          counts.push_back(count);
-          lags.push_back(lag_per_msg);
-        } else {
-          std::cout << "Number of message sent: <1/s" << std::endl;
-        }
-
-        if (++seconds == SECONDS) break;
-        count = 0;
-        lag = 0;
-        start = std::chrono::system_clock::now();
+        counts.push_back(count);
+        lags.push_back(lag_per_msg);
+      } else {
+        std::cout << "Number of message sent: <1/s" << std::endl;
       }
+
+      if (++seconds == SECONDS) break;
+      count = 0;
+      lag = 0;
+      start = std::chrono::system_clock::now();
     }
-
-    std::cout << "Total msgs sent in 10 seconds: " << total_count << std::endl;
-
-    auto mean_count = get_mean(counts);
-    auto stdd_count = get_stddev(counts);
-    std::cout << "Msg: " << mean_count << " ± " << stdd_count << std::endl;
-
-    auto mean_lag = get_mean(lags);
-    auto stdd_lag = get_stddev(lags);
-    std::cout << "Lag: " << mean_lag << " ± " << stdd_lag << TIMESCALE_NAME
-              << std::endl;
-  } else {
-    shm::memory::DefaultCopier cpy;
-    shm::pubsub::PublisherBin<QUEUE_SIZE> pub(topic, &cpy);
-
-    auto *rawptr = malloc(VECTOR_SIZE);
-    std::memset(rawptr, 255, VECTOR_SIZE);
-    Message *msg = reinterpret_cast<Message *>(rawptr);
-
-    std::cout << "Number of bytes = " << VECTOR_SIZE << std::endl;
-
-    auto start = std::chrono::system_clock::now();
-    while (true) {
-      msg->timestamp = std::chrono::duration_cast<TIMESCALE>(
-                           std::chrono::system_clock::now().time_since_epoch())
-                           .count();
-      pub.publish(msg, VECTOR_SIZE);
-      auto end = std::chrono::system_clock::now();
-      auto diff = std::chrono::duration_cast<TIMESCALE>(end - start);
-      if (diff.count() > (SECONDS + 2) * TIMESCALE_COUNT) break;
-    }
-    free(msg);
   }
+
+  std::cout << "Total msgs sent in 10 seconds: " << total_count << std::endl;
+
+  auto mean_count = get_mean(counts);
+  auto stdd_count = get_stddev(counts);
+  std::cout << "Msg: " << mean_count << " ± " << stdd_count << std::endl;
+
+  auto mean_lag = get_mean(lags);
+  auto stdd_lag = get_stddev(lags);
+  std::cout << "Lag: " << mean_lag << " ± " << stdd_lag << TIMESCALE_NAME
+            << std::endl;
+}
+
+void publish_loop() {
+  shm::memory::DefaultCopier cpy;
+  shm::pubsub::Publisher<QUEUE_SIZE> pub(topic, &cpy);
+
+  auto *rawptr = malloc(VECTOR_SIZE);
+  std::memset(rawptr, 255, VECTOR_SIZE);
+  Message *msg = reinterpret_cast<Message *>(rawptr);
+
+  std::cout << "Number of bytes = " << VECTOR_SIZE << std::endl;
+
+  auto start = std::chrono::system_clock::now();
+  while (true) {
+    msg->timestamp = std::chrono::duration_cast<TIMESCALE>(
+                         std::chrono::system_clock::now().time_since_epoch())
+                         .count();
+    pub.publish(msg, VECTOR_SIZE);
+    auto end = std::chrono::system_clock::now();
+    auto diff = std::chrono::duration_cast<TIMESCALE>(end - start);
+    if (diff.count() > (SECONDS + 2) * TIMESCALE_COUNT) break;
+  }
+  free(msg);
+}
+
+int main() {
+  std::thread subscribe_thread(subscribe_loop);
+  std::thread publish_thread(publish_loop);
+
+  subscribe_thread.join();
+  publish_thread.join();
 }

--- a/test/pubsub_test.cpp
+++ b/test/pubsub_test.cpp
@@ -135,7 +135,8 @@ void subscribe_loop() {
 }
 
 void publish_loop() {
-  shm::pubsub::SerializedPublisher<BenchmarkMsg, QUEUE_SIZE> pub(topic);
+  shm::pubsub::SerializedPublisher<BenchmarkMsg, QUEUE_SIZE> pub(topic,
+                                                                 nullptr);
 
   msgpack::sbuffer buf;
   msgpack::pack(buf, BenchmarkMsg(VECTOR_SIZE));

--- a/test/pubsub_test.cpp
+++ b/test/pubsub_test.cpp
@@ -30,8 +30,8 @@ SOFTWARE.
 #include "shadesmar.h"
 #else
 #include "shadesmar/message.h"
-#include "shadesmar/pubsub/publisher.h"
-#include "shadesmar/pubsub/subscriber.h"
+#include "shadesmar/pubsub/serialized_publisher.h"
+#include "shadesmar/pubsub/serialized_subscriber.h"
 #endif
 
 const char topic[] = "benchmark_topic";
@@ -90,68 +90,75 @@ void callback(const std::shared_ptr<BenchmarkMsg> &msg) {
   }
 }
 
-int main() {
-  if (fork() == 0) {
-    std::vector<int> counts;
-    std::vector<double> lags;
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-    shm::pubsub::Subscriber<BenchmarkMsg, QUEUE_SIZE> sub(topic, callback,
-                                                          EXTRA_COPY);
-    auto start = std::chrono::system_clock::now();
-    int seconds = 0;
-    while (true) {
-      sub.spin_once();
-      auto end = std::chrono::system_clock::now();
-      auto diff = std::chrono::duration_cast<TIMESCALE>(end - start);
+void subscribe_loop() {
+  std::vector<int> counts;
+  std::vector<double> lags;
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  shm::pubsub::SerializedSubscriber<BenchmarkMsg, QUEUE_SIZE> sub(topic,
+                                                                  callback);
+  auto start = std::chrono::system_clock::now();
+  int seconds = 0;
+  while (true) {
+    sub.spin_once();
+    auto end = std::chrono::system_clock::now();
+    auto diff = std::chrono::duration_cast<TIMESCALE>(end - start);
 
-      if (diff.count() > TIMESCALE_COUNT) {
-        double lag_per_msg = static_cast<double>(lag) / count;
-        if (count != 0) {
-          std::cout << "Number of msgs sent: " << count << "/s" << std::endl;
-          std::cout << "Average Lag: " << lag_per_msg << TIMESCALE_NAME
-                    << std::endl;
-          counts.push_back(count);
-          lags.push_back(lag_per_msg);
-        } else {
-          std::cout << "Number of message sent: <1/s" << std::endl;
-        }
-
-        if (++seconds == SECONDS) break;
-        count = 0;
-        lag = 0;
-        start = std::chrono::system_clock::now();
+    if (diff.count() > TIMESCALE_COUNT) {
+      double lag_per_msg = static_cast<double>(lag) / count;
+      if (count != 0) {
+        std::cout << "Number of msgs sent: " << count << "/s" << std::endl;
+        std::cout << "Average Lag: " << lag_per_msg << TIMESCALE_NAME
+                  << std::endl;
+        counts.push_back(count);
+        lags.push_back(lag_per_msg);
+      } else {
+        std::cout << "Number of message sent: <1/s" << std::endl;
       }
-    }
 
-    std::cout << "Total msgs sent in 10 seconds: " << total_count << std::endl;
-
-    auto mean_count = get_mean(counts);
-    auto stdd_count = get_stddev(counts);
-    std::cout << "Msg: " << mean_count << " ± " << stdd_count << std::endl;
-
-    auto mean_lag = get_mean(lags);
-    auto stdd_lag = get_stddev(lags);
-    std::cout << "Lag: " << mean_lag << " ± " << stdd_lag << TIMESCALE_NAME
-              << std::endl;
-
-  } else {
-    shm::pubsub::Publisher<BenchmarkMsg, QUEUE_SIZE> pub(topic);
-
-    msgpack::sbuffer buf;
-    msgpack::pack(buf, BenchmarkMsg(VECTOR_SIZE));
-
-    std::cout << "Number of bytes = " << buf.size() << std::endl;
-
-    auto start = std::chrono::system_clock::now();
-
-    int i = 0;
-    while (true) {
-      BenchmarkMsg msg(++i);
-      msg.init_time();
-      pub.publish(msg);
-      auto end = std::chrono::system_clock::now();
-      auto diff = std::chrono::duration_cast<TIMESCALE>(end - start);
-      if (diff.count() > (SECONDS + 1) * TIMESCALE_COUNT) break;
+      if (++seconds == SECONDS) break;
+      count = 0;
+      lag = 0;
+      start = std::chrono::system_clock::now();
     }
   }
+
+  std::cout << "Total msgs sent in 10 seconds: " << total_count << std::endl;
+
+  auto mean_count = get_mean(counts);
+  auto stdd_count = get_stddev(counts);
+  std::cout << "Msg: " << mean_count << " ± " << stdd_count << std::endl;
+
+  auto mean_lag = get_mean(lags);
+  auto stdd_lag = get_stddev(lags);
+  std::cout << "Lag: " << mean_lag << " ± " << stdd_lag << TIMESCALE_NAME
+            << std::endl;
+}
+
+void publish_loop() {
+  shm::pubsub::SerializedPublisher<BenchmarkMsg, QUEUE_SIZE> pub(topic);
+
+  msgpack::sbuffer buf;
+  msgpack::pack(buf, BenchmarkMsg(VECTOR_SIZE));
+
+  std::cout << "Number of bytes = " << buf.size() << std::endl;
+
+  auto start = std::chrono::system_clock::now();
+
+  int i = 0;
+  while (true) {
+    BenchmarkMsg msg(++i);
+    msg.init_time();
+    pub.publish(msg);
+    auto end = std::chrono::system_clock::now();
+    auto diff = std::chrono::duration_cast<TIMESCALE>(end - start);
+    if (diff.count() > (SECONDS + 1) * TIMESCALE_COUNT) break;
+  }
+}
+
+int main() {
+  std::thread subscribe_thread(subscribe_loop);
+  std::thread publish_thread(publish_loop);
+
+  subscribe_thread.join();
+  publish_thread.join();
 }


### PR DESCRIPTION
Closes #33

This changes the API significantly for `shm::pubsub`:

1. `SubscriberBin` -> `Subscriber` & `PublisherBin` -> `Publisher`. 
2. `Subscriber` -> `SerializedSubscriber` (similar for `Publisher`).
3. `SubscirberBin` and `Subscriber` used to inherit from `SubscriberBase`. This is no longer the base. They are independent. 
4. All `pubsub` classes now take `shm::memory::Copier*` as the last constructor param and has full support for custom copiers.
5. The `extra_copy` param in the constructors the older `Publisher` and `Subscriber` has been removed. 
6. The `Serialized` versions sit in their own separate header files: `shadesmar/pubsub/serialized_{publisher|subscriber}.h`.

The main `README.md` has been updated to reflect the new API.  