### PR TITLE
Stronger multithreaded allocator test

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -12,10 +12,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install dependencies
       run: ./scripts/install_deps.sh
-    - name: Configure Release
+    - name: Configure
       env:
         CXX: ${{ matrix.compiler }}
-      run: ./configure
+      run: ./configure Debug
     - name: Build
       run: cmake --build build
     - name: Tests
@@ -28,7 +28,7 @@ jobs:
     - name: Install dependencies
       run: ./scripts/install_deps.sh
     - name: Configure
-      run: ./configure Release
+      run: ./configure Debug
     - name: Build
       run: cmake --build build
     - name: Tests

--- a/test/allocator_test.cpp
+++ b/test/allocator_test.cpp
@@ -22,6 +22,8 @@ SOFTWARE.
 ==============================================================================*/
 
 #include <cstdlib>
+#include <cstring>
+#include <numeric>
 #include <thread>
 #include <vector>
 
@@ -148,35 +150,58 @@ void cyclic() {
   free(alloc);
 }
 
-void multithread(int nthreads) {
-  auto *alloc = new_alloc(128 * nthreads);
+void multithread(int nthreads, std::vector<int> &&allocs) {
+  auto *alloc = new_alloc(2 * std::accumulate(allocs.begin(), allocs.end(), 0) *
+                          nthreads);
+
+  auto rand_sleep = [](uint32_t factor) {
+    // Sleep between (0, factor) microseconds
+    uint32_t timeout =
+        static_cast<float>(rand() / static_cast<float>(RAND_MAX)) * factor;
+    std::this_thread::sleep_for(std::chrono::microseconds(timeout));
+  };
 
   std::vector<std::thread> threads;
   threads.reserve(nthreads);
   for (int t = 0; t < nthreads; ++t) {
-    threads.emplace_back([&]() {
+    threads.emplace_back([&, t]() {
       int iters = 100;
       while (iters--) {
-        auto *p1 = alloc->alloc(16);
-        auto *p2 = alloc->alloc(10);
 
-        assert(p1 != nullptr);
-        assert(p2 != nullptr);
+        std::vector<uint8_t *> ps(allocs.size());
 
-        int max_tries = nthreads * nthreads;
+        for (int i = 0; i < allocs.size(); ++i) {
+          ps[i] = alloc->alloc(allocs[i]);
+          rand_sleep(10);
+        }
 
+        for (int i = 0; i < ps.size(); ++i) {
+          assert(ps[i] != nullptr);
+          std::memset(ps[i], ps.size() * t + i, allocs[i]);
+        }
+
+        rand_sleep(100);
+
+        for (int i = 0; i < ps.size(); ++i) {
+          for (int l = 0; l < allocs[i]; ++i) {
+            assert(ps[i][l] == static_cast<uint8_t>(ps.size() * t + i));
+          }
+        }
+
+        int max_tries = std::max(nthreads * nthreads, 100);
         auto timed_free_loop = [&](uint8_t *p) -> bool {
           for (int i = 0; i < max_tries; ++i) {
             if (alloc->free(p)) {
               return true;
             }
-            std::this_thread::sleep_for(std::chrono::microseconds(50));
+            rand_sleep(50);
           }
           return false;
         };
 
-        assert(timed_free_loop(p1));
-        assert(timed_free_loop(p2));
+        for (auto p : ps) {
+          assert(timed_free_loop(p));
+        }
       }
     });
   }
@@ -194,5 +219,5 @@ int main() {
   wrap_around();
   cyclic();
 
-  multithread(128);  // FLAKY
+  multithread(128, {100, 2000, 30000});
 }


### PR DESCRIPTION
Adds stronger tests for the allocator. In parallel, make a series of allocations, write some data, free and check data, and free it. It sleeps randomly between each step to make the test less deterministic (to reflect real-world use-case). 

Works without issue for 128 threads. Should work for higher, 128 was chosen as an assumed real-world worst-case.