### PR TITLE
Remove queue_size template parameter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,3 @@
 # Generated from CLion C/C++ Code Style settings
 BasedOnStyle: Google
+ColumnLimit: 79

--- a/include/shadesmar/concurrency/rw_lock.h
+++ b/include/shadesmar/concurrency/rw_lock.h
@@ -67,7 +67,9 @@ void PthreadReadWriteLock::lock_sharable() { pthread_rwlock_rdlock(&rwlock); }
 bool PthreadReadWriteLock::try_lock_sharable() {
   return (!pthread_rwlock_tryrdlock(&rwlock));
 }
-void PthreadReadWriteLock::unlock_sharable() { pthread_rwlock_unlock(&rwlock); }
+void PthreadReadWriteLock::unlock_sharable() {
+  pthread_rwlock_unlock(&rwlock);
+}
 
 }  // namespace shm::concurrent
 #endif  // INCLUDE_SHADESMAR_CONCURRENCY_RW_LOCK_H_

--- a/include/shadesmar/macros.h
+++ b/include/shadesmar/macros.h
@@ -43,7 +43,8 @@ SOFTWARE.
     cmd;                                                                    \
     auto end = std::chrono::system_clock::now();                            \
     auto diff = std::chrono::duration_cast<TIMESCALE>(end - start).count(); \
-    DEBUG("Time for " << name << ": " << diff << TIMESCALE_NAME);           \
+    std::cout << "Time for " << name << ": " << diff << TIMESCALE_NAME      \
+              << std::endl;                                                 \
   } while (0);
 
 #else

--- a/include/shadesmar/memory/allocator.h
+++ b/include/shadesmar/memory/allocator.h
@@ -26,7 +26,7 @@ SOFTWARE.
 
 #include <cassert>
 
-#include "shadesmar/concurrency/lock.h"
+#include "shadesmar/concurrency/robust_lock.h"
 #include "shadesmar/concurrency/scope.h"
 
 namespace shm::memory {
@@ -35,7 +35,7 @@ class Allocator {
  public:
   using handle = uint64_t;
   template <concurrent::ExlOrShr type>
-  using Scope = concurrent::ScopeGuard<concurrent::PthreadWriteLock, type>;
+  using Scope = concurrent::ScopeGuard<concurrent::RobustLock, type>;
 
   Allocator(size_t offset, size_t size);
   uint8_t *alloc(uint32_t bytes);
@@ -64,7 +64,7 @@ class Allocator {
                                         offset_);
   }
 
-  concurrent::PthreadWriteLock lock_;
+  concurrent::RobustLock lock_;
 
   uint32_t alloc_index_;
   volatile uint32_t free_index_;

--- a/include/shadesmar/pubsub/publisher.h
+++ b/include/shadesmar/pubsub/publisher.h
@@ -36,7 +36,6 @@ SOFTWARE.
 
 namespace shm::pubsub {
 
-template <uint32_t queue_size>
 class Publisher {
  public:
   explicit Publisher(const std::string &topic_name, memory::Copier *copier);
@@ -44,18 +43,15 @@ class Publisher {
 
  private:
   std::string topic_name_;
-  std::unique_ptr<Topic<queue_size>> topic_;
+  std::unique_ptr<Topic> topic_;
 };
 
-template <uint32_t queue_size>
-Publisher<queue_size>::Publisher(const std::string &topic_name,
-                                 memory::Copier *copier)
+Publisher::Publisher(const std::string &topic_name, memory::Copier *copier)
     : topic_name_(topic_name) {
-  topic_ = std::make_unique<Topic<queue_size>>(topic_name, copier);
+  topic_ = std::make_unique<Topic>(topic_name, copier);
 }
 
-template <uint32_t queue_size>
-bool Publisher<queue_size>::publish(void *data, size_t size) {
+bool Publisher::publish(void *data, size_t size) {
   memory::Memblock memblock(data, size);
   return topic_->write(memblock);
 }

--- a/include/shadesmar/pubsub/serialized_publisher.h
+++ b/include/shadesmar/pubsub/serialized_publisher.h
@@ -32,7 +32,7 @@ SOFTWARE.
 
 namespace shm::pubsub {
 
-template <typename msgT, uint32_t queue_size>
+template <typename msgT>
 class SerializedPublisher {
  public:
   explicit SerializedPublisher(const std::string &topic_name,
@@ -42,29 +42,29 @@ class SerializedPublisher {
   bool publish(msgT *msg);
 
  private:
-  Publisher<queue_size> bin_pub_;
+  Publisher bin_pub_;
 };
 
-template <typename msgT, uint32_t queue_size>
-SerializedPublisher<msgT, queue_size>::SerializedPublisher(
-    const std::string &topic_name, memory::Copier *copier)
+template <typename msgT>
+SerializedPublisher<msgT>::SerializedPublisher(const std::string &topic_name,
+                                               memory::Copier *copier)
     : bin_pub_(topic_name, copier) {
   static_assert(std::is_base_of<BaseMsg, msgT>::value,
                 "msgT must derive from BaseMsg");
 }
 
-template <typename msgT, uint32_t queue_size>
-bool SerializedPublisher<msgT, queue_size>::publish(std::shared_ptr<msgT> msg) {
+template <typename msgT>
+bool SerializedPublisher<msgT>::publish(std::shared_ptr<msgT> msg) {
   return publish(msg.get());
 }
 
-template <typename msgT, uint32_t queue_size>
-bool SerializedPublisher<msgT, queue_size>::publish(msgT &msg) {  // NOLINT
+template <typename msgT>
+bool SerializedPublisher<msgT>::publish(msgT &msg) {  // NOLINT
   return publish(&msg);
 }
 
-template <typename msgT, uint32_t queue_size>
-bool SerializedPublisher<msgT, queue_size>::publish(msgT *msg) {
+template <typename msgT>
+bool SerializedPublisher<msgT>::publish(msgT *msg) {
   msgpack::sbuffer buf;
   try {
     msgpack::pack(buf, *msg);

--- a/include/shadesmar/pubsub/serialized_subscriber.h
+++ b/include/shadesmar/pubsub/serialized_subscriber.h
@@ -33,7 +33,7 @@ SOFTWARE.
 
 namespace shm::pubsub {
 
-template <typename msgT, uint32_t queue_size>
+template <typename msgT>
 class SerializedSubscriber {
   static_assert(std::is_base_of<BaseMsg, msgT>::value,
                 "msgT must derive from BaseMsg");
@@ -49,11 +49,11 @@ class SerializedSubscriber {
 
  private:
   std::function<void(const std::shared_ptr<msgT> &)> callback_;
-  Subscriber<queue_size> bin_sub_;
+  Subscriber bin_sub_;
 };
 
-template <typename msgT, uint32_t queue_size>
-SerializedSubscriber<msgT, queue_size>::SerializedSubscriber(
+template <typename msgT>
+SerializedSubscriber<msgT>::SerializedSubscriber(
     const std::string &topic_name,
     std::function<void(const std::shared_ptr<msgT> &)> callback,
     memory::Copier *copier)
@@ -61,8 +61,8 @@ SerializedSubscriber<msgT, queue_size>::SerializedSubscriber(
           topic_name, [](memory::Memblock *) {}, copier),
       callback_(std::move(callback)) {}
 
-template <typename msgT, uint32_t queue_size>
-void SerializedSubscriber<msgT, queue_size>::spin_once() {
+template <typename msgT>
+void SerializedSubscriber<msgT>::spin_once() {
   memory::Memblock memblock = bin_sub_.get_message();
 
   if (memblock.size == 0) {
@@ -77,8 +77,8 @@ void SerializedSubscriber<msgT, queue_size>::spin_once() {
   callback_(msg);
 }
 
-template <typename msgT, uint32_t queue_size>
-void SerializedSubscriber<msgT, queue_size>::spin() {}
+template <typename msgT>
+void SerializedSubscriber<msgT>::spin() {}
 
 }  // namespace shm::pubsub
 #endif  // INCLUDE_SHADESMAR_PUBSUB_SERIALIZED_SUBSCRIBER_H_

--- a/test/allocator_test.cpp
+++ b/test/allocator_test.cpp
@@ -36,8 +36,8 @@ SOFTWARE.
 
 shm::memory::Allocator *new_alloc(size_t size) {
   auto *memory = malloc(size + sizeof(shm::memory::Allocator));
-  auto *alloc =
-      new (memory) shm::memory::Allocator(sizeof(shm::memory::Allocator), size);
+  auto *alloc = new (memory)
+      shm::memory::Allocator(sizeof(shm::memory::Allocator), size);
   return alloc;
 }
 
@@ -151,8 +151,8 @@ void cyclic() {
 }
 
 void multithread(int nthreads, std::vector<int> &&allocs) {
-  auto *alloc = new_alloc(2 * std::accumulate(allocs.begin(), allocs.end(), 0) *
-                          nthreads);
+  auto *alloc = new_alloc(
+      2 * std::accumulate(allocs.begin(), allocs.end(), 0) * nthreads);
 
   std::vector<std::thread> threads;
   threads.reserve(nthreads);

--- a/test/micro_benchmark.cpp
+++ b/test/micro_benchmark.cpp
@@ -103,7 +103,7 @@ void bench_lock() {
    * All take ~1500ns
    * Peaks at ~100us when prune_sharable is called
    */
-  shm::concurrent::RobustLock lock;
+  shm::concurrent::PthreadReadWriteLock lock;
 
   TIMEIT({ lock.lock(); }, "lock");
   TIMEIT({ lock.unlock(); }, "unlock");

--- a/test/pubsub_bin_test.cpp
+++ b/test/pubsub_bin_test.cpp
@@ -35,7 +35,6 @@ SOFTWARE.
 #endif
 
 const char topic[] = "raw_benchmark_topic";
-const int QUEUE_SIZE = 16;
 const int SECONDS = 10;
 const int VECTOR_SIZE = 10 * 1024 * 1024;
 
@@ -82,7 +81,7 @@ void subscribe_loop() {
   std::vector<double> lags;
   std::this_thread::sleep_for(std::chrono::seconds(1));
   shm::memory::DefaultCopier cpy;
-  shm::pubsub::Subscriber<QUEUE_SIZE> sub(topic, callback, &cpy);
+  shm::pubsub::Subscriber sub(topic, callback, &cpy);
   auto start = std::chrono::system_clock::now();
   int seconds = 0;
   while (true) {
@@ -124,7 +123,7 @@ void subscribe_loop() {
 
 void publish_loop() {
   shm::memory::DefaultCopier cpy;
-  shm::pubsub::Publisher<QUEUE_SIZE> pub(topic, &cpy);
+  shm::pubsub::Publisher pub(topic, &cpy);
 
   auto *rawptr = malloc(VECTOR_SIZE);
   std::memset(rawptr, 255, VECTOR_SIZE);

--- a/test/pubsub_test.cpp
+++ b/test/pubsub_test.cpp
@@ -35,7 +35,6 @@ SOFTWARE.
 #endif
 
 const char topic[] = "benchmark_topic";
-const int QUEUE_SIZE = 16;
 const int SECONDS = 10;
 const int VECTOR_SIZE = 10 * 1024 * 1024;
 
@@ -93,8 +92,7 @@ void subscribe_loop() {
   std::vector<int> counts;
   std::vector<double> lags;
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  shm::pubsub::SerializedSubscriber<BenchmarkMsg, QUEUE_SIZE> sub(topic,
-                                                                  callback);
+  shm::pubsub::SerializedSubscriber<BenchmarkMsg> sub(topic, callback);
   auto start = std::chrono::system_clock::now();
   int seconds = 0;
   while (true) {
@@ -134,8 +132,7 @@ void subscribe_loop() {
 }
 
 void publish_loop() {
-  shm::pubsub::SerializedPublisher<BenchmarkMsg, QUEUE_SIZE> pub(topic,
-                                                                 nullptr);
+  shm::pubsub::SerializedPublisher<BenchmarkMsg> pub(topic, nullptr);
 
   msgpack::sbuffer buf;
   msgpack::pack(buf, BenchmarkMsg(VECTOR_SIZE));


### PR DESCRIPTION
`Memory` could have a variable-sized underlying circular buffer, but the size had to be passed as a template parameter during compile time. This meant that most of the implementation was restricted to header files.

Removing this makes the implementation of the end-points for both PubSub/RPC much nicer; in that, it requires no template parameters. Instead of the variable-sized circular buffer, we stick to a fixed size of *128*. It handles recency constraints; I can introduce a "Policy" type. Or re-visit runtime parameter for Memory.

ALSO: Refactor `Topic` and `Channel` to use `Memory` via composition instead of inheritance. I have no idea why I went with inheritance in the first place.